### PR TITLE
Fix .vimrc usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,7 @@ Add the following lines to your `vimrc`
 
 ```vim
 " Octave syntax
-augroup filetypedetect
-  autocmd!
-  autocmd BufRead,BufNewFile *.m,*.oct setlocal filetype=octave
-augroup END
+autocmd BufRead,BufNewFile *.m,*.oct set ft=octave
 ```
 
 Omni completion should works out-of-box by setting

--- a/README.md
+++ b/README.md
@@ -59,12 +59,5 @@ Note that this plugin contributes to
 
 ## Usage
 
-Add the following lines to your `vimrc`
-
-```vim
-" Octave syntax
-autocmd BufRead,BufNewFile *.m,*.oct set ft=octave
-```
-
-Omni completion should works out-of-box by setting
+Plugin should work out of the box. You can enable omni completion by setting
 `omnifunc=syntaxcomplete#Complete`.

--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ Note that this plugin contributes to
 
 ## Usage
 
-Plugin should work out of the box. You can enable omni completion by setting
-`omnifunc=syntaxcomplete#Complete`.
+The plugin should work out of the box.  You can enable omni completion
+by setting `omnifunc=syntaxcomplete#Complete`.

--- a/ftdetect/octave.vim
+++ b/ftdetect/octave.vim
@@ -1,0 +1,1 @@
+au! BufRead,BufNewFile *.m,*.oct setlocal filetype=octave


### PR DESCRIPTION
You cannot do it your way beucase autocmd! would reset all default vim autocommands for filetypes, including other extensions