### PR TITLE
feat: Set commentstring in ftplugin

### DIFF
--- a/ftplugin/octave.vim
+++ b/ftplugin/octave.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=%\ %s


### PR DESCRIPTION
Sets the `commentstring` variable for octave filetypes. See #2 for details on implementation

Fixes #2